### PR TITLE
remaking app init

### DIFF
--- a/cmd/brutefp-cli/main.go
+++ b/cmd/brutefp-cli/main.go
@@ -31,5 +31,11 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 	defer cancel()
 
-	app.Execute(ctx, app.NewBruteFPCli(cfg))
+	appCli, err := app.NewBruteFPCli(ctx, cfg)
+	if err != nil {
+		log.Printf("can't initialize application: %s\n", err)
+		cancel()
+		return
+	}
+	app.Execute(ctx, appCli)
 }

--- a/cmd/brutefp/main.go
+++ b/cmd/brutefp/main.go
@@ -31,5 +31,11 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 	defer cancel()
 
-	app.Execute(ctx, app.NewBruteFP(cfg))
+	appBFP, err := app.NewBruteFP(ctx, cfg)
+	if err != nil {
+		log.Printf("can't initialize application: %s\n", err)
+		cancel()
+		return
+	}
+	app.Execute(ctx, appBFP)
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -8,7 +8,6 @@ import (
 )
 
 type App interface {
-	Initialize(ctx context.Context) error
 	Run(ctx context.Context) error
 	Close()
 }
@@ -23,11 +22,6 @@ func Execute(ctx context.Context, app App) {
 	// пропишем defer на закрытие приложения до инициализации.
 	defer app.Close()
 
-	if err := app.Initialize(ctx); err != nil {
-		stdlog.Printf("can't initialize application: %s\n", err)
-		cancel()
-		return
-	}
 	if err := app.Run(ctx); err != nil {
 		stdlog.Printf("can't run application: %s\n", err)
 		cancel()


### PR DESCRIPTION
Касательно предыдущего комментария 
> Всю работу по созданию коннектов лучше делать в конструкторе. При таком подходе после вызова конструктора в коде будет получен объект, с которым можно полноценно работать: у него будут все нужные коннекты, будет выделена необходимая память (например, под мапы или каналы) и если в процессе создания объекта что-то пойдет не так, это будет сразу понятно и до вызова методов дело не дойдет.
Если делать эти действия в отдельном методе, то можно забыть его вызвать или вызвать не в правильном порядке.

Вообще, я везде придерживался всегда этого правила, но в случае инициализации объекта приложения я разделил его логику на:
1. **инициализацию**: тут я как раз создаю ресурсы и различные мапы
2. **исполнение**: тут запускаю сервисы
3. **закрытие**: тут закрываю ресурсы и запущенные рутины

Процедура инициализации действительно выглядит как лишняя с потенциальным отстрелом ноги, поэтому 
1. я убрал ее из интерфейса приложения
2. весь функционал перенес в конструктор

Правда полной инкапсуляции все равно не получается, так как 
1. Структура приложения остается публичной и ее потенциально можно создать не через конструктор.
2. Для закрытия приложения все равно нужен отдельный метод чтобы не сваливать все в один метод. Я так понимаю поэтому выделяется особый интерфейс io.Closer, чтобы как-то пофиксить отсутствие деструторов

Дайте пожалуйста последний камент :-)